### PR TITLE
Remove unnessessary identity from azure group

### DIFF
--- a/app_azure_test.go
+++ b/app_azure_test.go
@@ -49,22 +49,18 @@ var (
 		DisplayName:   bobAzure.DisplayName,
 	}
 	devsAzureGroup = AzureGroup{
-		Identity:    "acme.devs|all",
 		AzureID:     "fake-az-acme.devs",
 		DisplayName: "acme.devs|all",
 	}
 	hqAzureGroup = AzureGroup{
-		Identity:    "acme.hq",
 		AzureID:     "fake-az-acme.hq",
 		DisplayName: "acme.hq",
 	}
 	devsAzureGroupChangedDisplayName = AzureGroup{
-		Identity:    "acme.developers|all",
 		AzureID:     devsAzureGroup.AzureID,
 		DisplayName: "acme.developers|all",
 	}
 	hqAzureGroupChangedBackwardCompatible = AzureGroup{
-		Identity:    "acme.hq|all",
 		AzureID:     hqAzureGroup.AzureID,
 		DisplayName: "acme.hq|all",
 	}
@@ -153,7 +149,6 @@ var (
 		SourceRaw: map[string]any{
 			"id":           devsAzureGroup.AzureID,
 			"display_name": "acme.devs|all",
-			"identity":     "acme.devs|all",
 		},
 	}
 	qaYtsaurusGroup = YtsaurusGroup{
@@ -161,7 +156,6 @@ var (
 		SourceRaw: map[string]any{
 			"id":           "fake-az-acme.qa",
 			"display_name": "acme.qa|all",
-			"identity":     "acme.qa",
 		},
 	}
 	hqYtsaurusGroup = YtsaurusGroup{
@@ -169,7 +163,6 @@ var (
 		SourceRaw: map[string]any{
 			"id":           hqAzureGroup.AzureID,
 			"display_name": "acme.hq",
-			"identity":     "acme.hq",
 		},
 	}
 	devsYtsaurusGroupChangedDisplayName = YtsaurusGroup{
@@ -177,7 +170,6 @@ var (
 		SourceRaw: map[string]any{
 			"id":           devsAzureGroup.AzureID,
 			"display_name": "acme.developers|all",
-			"identity":     "acme.developers|all",
 		},
 	}
 	hqYtsaurusGroupChangedBackwardCompatible = YtsaurusGroup{
@@ -185,7 +177,6 @@ var (
 		SourceRaw: map[string]any{
 			"id":           hqAzureGroup.AzureID,
 			"display_name": "acme.hq|all",
-			"identity":     "acme.hq|all",
 		},
 	}
 

--- a/azure_models.go
+++ b/azure_models.go
@@ -53,10 +53,6 @@ func (au AzureUser) GetRaw() (map[string]any, error) {
 }
 
 type AzureGroup struct {
-	// Identity is unique human-readable Source user field, used (possibly with changes)
-	// for the corresponding YTsaurus user's `name` attribute.
-	Identity string `yson:"identity"`
-
 	AzureID     ObjectID `yson:"id"`
 	DisplayName string   `yson:"display_name"`
 }
@@ -80,7 +76,7 @@ func (ag AzureGroup) GetID() ObjectID {
 }
 
 func (ag AzureGroup) GetName() string {
-	return ag.Identity
+	return ag.DisplayName
 }
 
 func (ag AzureGroup) GetRaw() (map[string]any, error) {

--- a/azure_models_test.go
+++ b/azure_models_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestAzureUser ensures that raw representation has expected value.
+func TestAzureUser(t *testing.T) {
+	rawUser, err := AzureUser{
+		PrincipalName: "alice@acme.com",
+		AzureID:       "fake-az-id-alice",
+		Email:         "alice@acme.com",
+		FirstName:     "Alice",
+		LastName:      "Henderson",
+		DisplayName:   "Henderson, Alice (ACME)",
+	}.GetRaw()
+	require.NoError(t, err)
+
+	require.Equal(
+		t,
+		map[string]any{
+			"principal_name": "alice@acme.com",
+			"id":             "fake-az-id-alice",
+			"email":          "alice@acme.com",
+			"first_name":     "Alice",
+			"last_name":      "Henderson",
+			"display_name":   "Henderson, Alice (ACME)",
+		},
+		rawUser,
+	)
+}
+
+// TestAzureGroup ensures that raw representation has expected value.
+func TestAzureGroup(t *testing.T) {
+	rawGroup, err := AzureGroup{
+		AzureID:     "fake-az-acme.devs",
+		DisplayName: "acme.devs|all",
+	}.GetRaw()
+	require.NoError(t, err)
+
+	require.Equal(
+		t,
+		map[string]any{
+			"id":           "fake-az-acme.devs",
+			"display_name": "acme.devs|all",
+		},
+		rawGroup,
+	)
+}

--- a/azure_real.go
+++ b/azure_real.go
@@ -206,7 +206,6 @@ func (a *AzureReal) GetGroupsWithMembers() ([]SourceGroupWithMembers, error) {
 		groups = append(groups,
 			SourceGroupWithMembers{
 				SourceGroup: AzureGroup{
-					Identity:    displayName,
 					AzureID:     id,
 					DisplayName: displayName,
 				},


### PR DESCRIPTION
It was not stored in `@azure` before and now is which was not intended. But I though we don't need that extra complexity and have deleted it.