### PR TITLE
Fix error on group update without name change

### DIFF
--- a/ytsaurus.go
+++ b/ytsaurus.go
@@ -265,7 +265,7 @@ func (y *Ytsaurus) UpdateGroup(groupname string, group YtsaurusGroup) error {
 
 	y.maybePrintExtraLogs(groupname, "update_group", "groupname", groupname, "group", groupname)
 	y.maybePrintExtraLogs(group.Name, "update_group", "groupname", groupname, "group", group)
-	return doSetAttributesForYtsaurusGroup(
+	return doSetAttributesForYtsaurusGroupUpdate(
 		ctx,
 		y.client,
 		groupname,

--- a/ytsaurus_helpers.go
+++ b/ytsaurus_helpers.go
@@ -219,7 +219,13 @@ func doSetAzureAttributeForYtsaurusGroup(
 	)
 }
 
-func doSetAttributesForYtsaurusGroup(ctx context.Context, client yt.Client, groupname string, attrs map[string]any) error {
+func doSetAttributesForYtsaurusGroupUpdate(ctx context.Context, client yt.Client, groupname string, attrs map[string]any) error {
+	if groupname == attrs[nameAttributeName] {
+		// otherwise we'll got
+		// method: "multiset_attributes"
+		// error setting builtin attribute "name"
+		delete(attrs, nameAttributeName)
+	}
 	return client.MultisetAttributes(
 		ctx,
 		ypath.Path("//sys/groups/"+groupname+"/@"),


### PR DESCRIPTION
Currently we have 
```
 error setting builtin attribute \"name\"\n     path:     \"//sys/groups/xxx/@\"\n    group \"xxx\" already exists\
```
on group update without name change.