### PR TITLE
Post filter regex instead of suffix for Azure

### DIFF
--- a/azure_config.example.yaml
+++ b/azure_config.example.yaml
@@ -17,7 +17,7 @@ azure:
   timeout: 1s
   users_filter: "(accountEnabled eq true) and (userType eq 'Member')"
   groups_filter: "displayName -ne ''"
-  groups_display_name_suffix_post_filter: ".dev"
+  groups_display_name_regex_post_filter: "\\.dev$"
 
 ytsaurus:
   proxy: localhost:10110

--- a/config.go
+++ b/config.go
@@ -53,9 +53,11 @@ type AzureConfig struct {
 	GroupsFilter string `yaml:"groups_filter"`
 
 	// TODO(nadya73): support for ldap also, but with other name.
-	// GroupsDisplayNameSuffixPostFilter applied to the fetched groups display names.
-	GroupsDisplayNameSuffixPostFilter string        `yaml:"groups_display_name_suffix_post_filter"`
-	Timeout                           time.Duration `yaml:"timeout"`
+	// GroupsDisplayNameSuffixPostFilter is deprecated: use GroupsDisplayNameRegexPostFilter instead.
+	GroupsDisplayNameSuffixPostFilter string `yaml:"groups_display_name_suffix_post_filter"`
+	// GroupsDisplayNameRegexPostFilter applied to the fetched groups display names.
+	GroupsDisplayNameRegexPostFilter string        `yaml:"groups_display_name_regex_post_filter"`
+	Timeout                          time.Duration `yaml:"timeout"`
 
 	// TODO(nadya73): support for ldap also, but with other name.
 	// DebugAzureIDs is a list of ids for which app will print more debug info in logs.

--- a/config_test.go
+++ b/config_test.go
@@ -35,7 +35,7 @@ func TestAzureConfig(t *testing.T) {
 	require.Equal(t, 1*time.Second, cfg.Azure.Timeout)
 	require.Equal(t, "(accountEnabled eq true) and (userType eq 'Member')", cfg.Azure.UsersFilter)
 	require.Equal(t, "displayName -ne ''", cfg.Azure.GroupsFilter)
-	require.Equal(t, ".dev", cfg.Azure.GroupsDisplayNameSuffixPostFilter)
+	require.Equal(t, `\.dev$`, cfg.Azure.GroupsDisplayNameRegexPostFilter)
 
 	require.Equal(t, "localhost:10110", cfg.Ytsaurus.Proxy)
 	require.Equal(t, true, cfg.Ytsaurus.ApplyUserChanges)


### PR DESCRIPTION
Support regex for groupnames post-filter for azure.
Suffix filter is not supported and raises error.