### PR TITLE
Add user groups filter for membership-based user sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.local.yaml
 specs
 .idea
+bin

--- a/azure_real.go
+++ b/azure_real.go
@@ -300,7 +300,7 @@ func (a *AzureReal) filterUsersByGroupMembership(ctx context.Context, users []mo
 	}
 
 	// Get groups that match the user groups filter using the new method
-	groups, err := a.getGroupsWithMembers(ctx, []string{"id"}, a.userGroupsFilter)
+	groups, err := a.getGroupsWithMembers(ctx, defaultGroupFieldsToSelect, a.userGroupsFilter)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get user groups for filtering")
 	}

--- a/azure_real_integration_test.go
+++ b/azure_real_integration_test.go
@@ -287,3 +287,121 @@ func TestDiffAzureGroupsNames(t *testing.T) {
 	}))
 	require.Empty(t, strDiff)
 }
+
+// TestUserGroupsFilterIntegration tests that UserGroupsFilter actually filters users
+// by comparing results with and without the filter. This test verifies that the filter
+// produces different results, ensuring the feature works correctly.
+func TestUserGroupsFilterIntegration(t *testing.T) {
+	cfg, err := loadConfig("config.local.yaml")
+	require.NoError(t, err)
+
+	logger, err := configureLogger(&cfg.Logging)
+	require.NoError(t, err)
+
+	// Test 1: Get users without UserGroupsFilter
+	configWithoutFilter := *cfg.Azure
+	configWithoutFilter.UserGroupsFilter = ""
+	azureWithoutFilter, err := NewAzureReal(&configWithoutFilter, logger)
+	require.NoError(t, err)
+
+	usersWithoutFilter, err := azureWithoutFilter.GetUsers()
+	require.NoError(t, err)
+	require.NotEmpty(t, usersWithoutFilter, "No users found - check your Azure setup")
+
+	t.Logf("Users without UserGroupsFilter: %d", len(usersWithoutFilter))
+
+	// Test 2: Get users with UserGroupsFilter
+	// Use the UserGroupsFilter from config if set, otherwise use a default
+	userGroupsFilter := cfg.Azure.UserGroupsFilter
+	if userGroupsFilter == "" {
+		// Skip test if no UserGroupsFilter is configured
+		t.Skip("No UserGroupsFilter configured in config.local.yaml - set user_groups_filter to run this test")
+	}
+
+	configWithFilter := *cfg.Azure
+	azureWithFilter, err := NewAzureReal(&configWithFilter, logger)
+	require.NoError(t, err)
+
+	usersWithFilter, err := azureWithFilter.GetUsers()
+	require.NoError(t, err)
+
+	t.Logf("Users with UserGroupsFilter '%s': %d", userGroupsFilter, len(usersWithFilter))
+
+	// Test 3: Verify the filter actually makes a difference
+	if len(usersWithFilter) == len(usersWithoutFilter) {
+		// Compare the actual users to see if they're different
+		usersWithoutFilterMap := make(map[string]bool)
+		for _, user := range usersWithoutFilter {
+			azureUser := user.(AzureUser)
+			usersWithoutFilterMap[azureUser.AzureID] = true
+		}
+
+		allSameUsers := true
+		for _, user := range usersWithFilter {
+			azureUser := user.(AzureUser)
+			if !usersWithoutFilterMap[azureUser.AzureID] {
+				allSameUsers = false
+				break
+			}
+		}
+
+		if allSameUsers {
+			t.Log("⚠️  UserGroupsFilter returned the same users - this could mean:")
+			t.Log("   - All users are members of the filtered groups (valid)")
+			t.Log("   - The filter is not working correctly (needs investigation)")
+			t.Log("   - Consider using a more restrictive filter for testing")
+		} else {
+			t.Log("✅ UserGroupsFilter returned same count but different users - filter is working")
+		}
+	} else {
+		// Different counts - filter is definitely working
+		t.Logf("✅ UserGroupsFilter successfully filtered %d users (from %d to %d)",
+			len(usersWithoutFilter)-len(usersWithFilter), len(usersWithoutFilter), len(usersWithFilter))
+
+		// Verify filtered users are a subset of all users
+		allUserIDs := make(map[string]bool)
+		for _, user := range usersWithoutFilter {
+			azureUser := user.(AzureUser)
+			allUserIDs[azureUser.AzureID] = true
+		}
+
+		for _, user := range usersWithFilter {
+			azureUser := user.(AzureUser)
+			require.True(t, allUserIDs[azureUser.AzureID],
+				"Filtered user %s (%s) should exist in unfiltered results",
+				azureUser.PrincipalName, azureUser.AzureID)
+		}
+
+		// Show some examples of filtered out users
+		filteredUserIDs := make(map[string]bool)
+		for _, user := range usersWithFilter {
+			azureUser := user.(AzureUser)
+			filteredUserIDs[azureUser.AzureID] = true
+		}
+
+		t.Log("Examples of users filtered out:")
+		count := 0
+		for _, user := range usersWithoutFilter {
+			if count >= 5 { // Limit to 5 examples
+				break
+			}
+			azureUser := user.(AzureUser)
+			if !filteredUserIDs[azureUser.AzureID] {
+				t.Logf("  - %s (%s)", azureUser.PrincipalName, azureUser.DisplayName)
+				count++
+			}
+		}
+	}
+
+	// Test 4: Verify structure of filtered users is correct
+	for i, user := range usersWithFilter {
+		if i >= 3 { // Just check first 3 users
+			break
+		}
+		azureUser, ok := user.(AzureUser)
+		require.True(t, ok, "User should be of type AzureUser")
+		require.NotEmpty(t, azureUser.AzureID, "User should have AzureID")
+		require.NotEmpty(t, azureUser.PrincipalName, "User should have PrincipalName")
+		t.Logf("Sample filtered user: %s (%s)", azureUser.PrincipalName, azureUser.DisplayName)
+	}
+}

--- a/config.go
+++ b/config.go
@@ -45,15 +45,18 @@ type AzureConfig struct {
 	ClientID           string `yaml:"client_id"`
 	ClientSecretEnvVar string `yaml:"client_secret_env_var"` // default: "AZURE_CLIENT_SECRET"
 
-	// UsersFilter is MS Graph $filter value used for user fetching requests.
+	// We are syncing 3 things: users, groups and memberships.
+	// Groups are synced using `groups_filter`.
+	// Users are synced using `users_filter` and optional `user_groups_filter`.
+	// N.B. `user_groups_filter` is a filter for fetching *groups* and their members, which later used to filter users,
+	// it works independently to `groups_filter`, since in general case groups from which we sync users and groups we
+	//want to have in the ytsaurus can be different set of groups.
+	// Memberships are synced from azure, skipping the memberships for users and groups which were filtered out.
+	// UsersFilter, UserGroupsFilter and GroupsFilter format is MS Graph $filter value used for user fetching requests.
 	// See https://learn.microsoft.com/en-us/graph/api/user-list?#optional-query-parameters
-	UsersFilter string `yaml:"users_filter"`
-	// UserGroupsFilter is MS Graph $filter value used for getting groups whose members will be synced as users.
-	// If empty, all users matching UsersFilter will be synced.
+	UsersFilter      string `yaml:"users_filter"`
 	UserGroupsFilter string `yaml:"user_groups_filter"`
-	// GroupsFilter is MS Graph $filter value used for group fetching requests.
-	// See https://learn.microsoft.com/en-us/graph/api/group-list
-	GroupsFilter string `yaml:"groups_filter"`
+	GroupsFilter     string `yaml:"groups_filter"`
 
 	// TODO(nadya73): support for ldap also, but with other name.
 	// GroupsDisplayNameSuffixPostFilter is deprecated: use GroupsDisplayNameRegexPostFilter instead.

--- a/config.go
+++ b/config.go
@@ -48,6 +48,9 @@ type AzureConfig struct {
 	// UsersFilter is MS Graph $filter value used for user fetching requests.
 	// See https://learn.microsoft.com/en-us/graph/api/user-list?#optional-query-parameters
 	UsersFilter string `yaml:"users_filter"`
+	// UserGroupsFilter is MS Graph $filter value used for getting groups whose members will be synced as users.
+	// If empty, all users matching UsersFilter will be synced.
+	UserGroupsFilter string `yaml:"user_groups_filter"`
 	// GroupsFilter is MS Graph $filter value used for group fetching requests.
 	// See https://learn.microsoft.com/en-us/graph/api/group-list
 	GroupsFilter string `yaml:"groups_filter"`

--- a/config.go
+++ b/config.go
@@ -45,18 +45,26 @@ type AzureConfig struct {
 	ClientID           string `yaml:"client_id"`
 	ClientSecretEnvVar string `yaml:"client_secret_env_var"` // default: "AZURE_CLIENT_SECRET"
 
-	// We are syncing 3 things: users, groups and memberships.
-	// Groups are synced using `groups_filter`.
-	// Users are synced using `users_filter` and optional `user_groups_filter`.
-	// N.B. `user_groups_filter` is a filter for fetching *groups* and their members, which later used to filter users,
-	// it works independently to `groups_filter`, since in general case groups from which we sync users and groups we
-	//want to have in the ytsaurus can be different set of groups.
-	// Memberships are synced from azure, skipping the memberships for users and groups which were filtered out.
-	// UsersFilter, UserGroupsFilter and GroupsFilter format is MS Graph $filter value used for user fetching requests.
+	// We sync 3 entities independently: users, groups, and memberships.
+	//
+	// USERS are filtered using TWO filters applied sequentially:
+	// 1. `users_filter` - MS Graph $filter for user requests (e.g., accountEnabled eq true)
+	// 2. `user_groups_filter` - MS Graph $filter for group requests to get groups whose members will be synced as users
+	//    This is needed because MS Graph user API doesn't support filtering by group membership.
+	//    Only users who match BOTH filters will be synced (users_filter AND membership in user_groups_filter groups).
+	//
+	// GROUPS are filtered independently using:
+	// - `groups_filter` - MS Graph $filter for group requests
+	//   This works independently from `user_groups_filter` because the set of groups you want to sync
+	//   may be different from the groups whose members you want to sync as users.
+	//
+	// MEMBERSHIPS are synced from Azure, excluding memberships for users and groups that didn't match their respective filters.
+	//
+	// All filter formats follow MS Graph $filter OData syntax.
 	// See https://learn.microsoft.com/en-us/graph/api/user-list?#optional-query-parameters
-	UsersFilter      string `yaml:"users_filter"`
-	UserGroupsFilter string `yaml:"user_groups_filter"`
-	GroupsFilter     string `yaml:"groups_filter"`
+	UsersFilter      string `yaml:"users_filter"`      // Filter for MS Graph users API
+	UserGroupsFilter string `yaml:"user_groups_filter"` // Filter for MS Graph groups API to determine which users to sync
+	GroupsFilter     string `yaml:"groups_filter"`      // Filter for MS Graph groups API to determine which groups to sync
 
 	// TODO(nadya73): support for ldap also, but with other name.
 	// GroupsDisplayNameSuffixPostFilter is deprecated: use GroupsDisplayNameRegexPostFilter instead.

--- a/config.go
+++ b/config.go
@@ -62,7 +62,7 @@ type AzureConfig struct {
 	//
 	// All filter formats follow MS Graph $filter OData syntax.
 	// See https://learn.microsoft.com/en-us/graph/api/user-list?#optional-query-parameters
-	UsersFilter      string `yaml:"users_filter"`      // Filter for MS Graph users API
+	UsersFilter      string `yaml:"users_filter"`       // Filter for MS Graph users API
 	UserGroupsFilter string `yaml:"user_groups_filter"` // Filter for MS Graph groups API to determine which users to sync
 	GroupsFilter     string `yaml:"groups_filter"`      // Filter for MS Graph groups API to determine which groups to sync
 


### PR DESCRIPTION
## Summary
- Add UserGroupsFilter field to AzureConfig for filtering users by group membership
- Implement filterUsersByGroupMembership method to validate group membership
- Only sync users who are members of groups matching the specified filter

## Testing notes
1. Configure `user_groups_filter` in YAML config with MS Graph filter syntax
2. Verify only users from specified groups are synced
3. Test with empty filter to ensure all users are synced as before

## Areas of attention
- Performance impact when filtering large user sets
- Proper handling of groups with >20 members (msgraphExpandLimit)
- Error handling for group membership queries